### PR TITLE
SpiNNakerTestBase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ for dirname, dirnames, filenames in os.walk(main_package_dir):
             package_data[package].append(filename)
 
 setup(
-    name="SpiNNarTestBase",
+    name="SpiNNakerTestBase",
     version=__version__,
     description="Tools for testing SpiNNaker platform",
     url="https://github.com/SpiNNakerManchester/Testbase",


### PR DESCRIPTION
I noticed that SpiNNakerTestBase was not included in requirements-test.txt while it is needed in tests or at least integration tests.

This can and probably should go in before the release.

This PR must be done before the others:
https://github.com/SpiNNakerManchester/SpiNNGym/pull/22
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/187
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1055
https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/73

The other repositories with script testing
integration_tests
microcircuit_model
PyNN8Examples
Do not have a requirements-test.txt or setup.py files


