### PR TITLE
allow some exception to be converted to SkipTest

### DIFF
--- a/spinnaker_testbase/root_script_builder.py
+++ b/spinnaker_testbase/root_script_builder.py
@@ -75,7 +75,8 @@ class RootScriptBuilder(object):
                     test_file.write(local_path)
                     test_file.write("\n")
                 else:
-                    name = local_path[:-3].replace(os.sep, "_").replace("-", "_")
+                    name = local_path[:-3].replace(os.sep, "_").replace(
+                        "-", "_")
                     skip_imports = skip_exceptions.get(a_script, None)
                     self.add_script(test_file, name, local_path, skip_imports)
 

--- a/spinnaker_testbase/root_script_builder.py
+++ b/spinnaker_testbase/root_script_builder.py
@@ -26,45 +26,90 @@ WARNING_LONG = "        # Warning this test takes {}.\n" \
 
 class RootScriptBuilder(object):
 
-    def add_scripts(self, a_dir, prefix_len, test_file, too_long, exceptions):
+    def add_script(self, test_file, name, local_path, skip_imports):
+        test_file.write("\n    def test_")
+        test_file.write(name)
+        test_file.write("(self):\n")
+        if skip_imports:
+            if isinstance(skip_imports, str):
+                skip_imports = [skip_imports]
+            for skip_import in skip_imports:
+                test_file.write("        ")
+                test_file.write(skip_import)
+                test_file.write("\n")
+        test_file.write("        self.check_script(\"")
+        test_file.write(local_path)
+        test_file.write("\"")
+        if skip_imports:
+            test_file.write(", skip_exceptions=[")
+            test_file.write(
+                ",".join(map(lambda x: x.split()[-1], skip_imports)))
+            test_file.write("]")
+        test_file.write(")\n")
+
+    def add_scripts(self, a_dir, prefix_len, test_file, too_long, exceptions,
+                    skip_exceptions):
         for a_script in os.listdir(a_dir):
             script_path = os.path.join(a_dir, a_script)
             if os.path.isdir(script_path) and not a_script.startswith("."):
                 self.add_scripts(
-                    script_path, prefix_len, test_file, too_long, exceptions)
+                    script_path, prefix_len, test_file, too_long, exceptions,
+                    skip_exceptions)
             if a_script.endswith(".py") and a_script != "__init__.py":
                 local_path = script_path[prefix_len:]
-                name = local_path[:-3].replace(os.sep, "_").replace("-", "_")
-                test_file.write("\n    def test_")
-                test_file.write(name)
-                test_file.write("(self):\n")
-                if a_script in too_long:
-                    # Lazy boolean distinction based on presence of parameter
-                    if len(sys.argv) > 1:  # 1 is the script name
-                        test_file.write(
-                            SKIP_TOO_LONG.format(too_long[a_script]))
-                    else:
-                        test_file.write(
-                            WARNING_LONG.format(too_long[a_script]))
-                        test_file.write(
-                            NO_SKIP_TOO_LONG.format(too_long[a_script]))
-
-                if a_script in exceptions:
-                    test_file.write("        raise SkipTest(\"{}\")\n".format(
-                        exceptions[a_script]))
-                test_file.write("        self.check_script(\"")
                 # As the paths are written to strings in files
                 # Windows needs help!
                 if platform.system() == "Windows":
                     local_path = local_path.replace("\\", "/")
-                test_file.write(local_path)
-                test_file.write("\")\n")
+                if a_script in too_long and len(sys.argv) > 1:
+                    # Lazy boolean distinction based on presence of parameter
+                    test_file.write("\n    # Not testing file due to: ")
+                    test_file.write(too_long[a_script])
+                    test_file.write("\n    # ")
+                    test_file.write(local_path)
+                    test_file.write("\n")
+                elif a_script in exceptions:
+                    test_file.write("\n    # Not testing file due to: ")
+                    test_file.write(exceptions[a_script])
+                    test_file.write("\n    # ")
+                    test_file.write(local_path)
+                    test_file.write("\n")
+                else:
+                    name = local_path[:-3].replace(os.sep, "_").replace("-", "_")
+                    skip_imports = skip_exceptions.get(a_script, None)
+                    self.add_script(test_file, name, local_path, skip_imports)
 
-    def create_test_scripts(self, dirs, too_long=None, exceptions=None):
+    def create_test_scripts(self, dirs, too_long=None, exceptions=None,
+                            skip_exceptions=None):
+        """
+
+        :param dirs: List of dirs to fins scripts in
+            These are relative paths to the repository
+        :type dirs: str or list(str)
+        :param too_long: Dict of files that take too long to run and how long
+            These are just the file name including the .py
+            They are mapped to a skip reason
+            These are only skip testes if asked to be (currently not done)
+        :type too_long: dict(str, str) or None
+        :param exceptions:  Dict of files that should be skipped
+            These are just the file name including the .py
+            They are mapped to a skip reason
+            These are always skipped
+        :type exceptions: dict(str, str) or None
+        :param skip_exceptions:
+            Dict of files and exc eptions to skip on
+            These are just the file name including the .py
+            They are mapped to a list of INDIVIUAL import statements
+            in the
+            from xyz import Abc
+            format.
+        """
         if too_long is None:
             too_long = {}
         if exceptions is None:
             exceptions = {}
+        if skip_exceptions is None:
+            skip_exceptions = {}
         if isinstance(dirs, str):
             dirs = [dirs]
 
@@ -81,4 +126,4 @@ class RootScriptBuilder(object):
             for script_dir in dirs:
                 a_dir = os.path.join(repository_dir, script_dir)
                 self.add_scripts(a_dir, len(repository_dir)+1, test_file,
-                                 too_long, exceptions)
+                                 too_long, exceptions, skip_exceptions)

--- a/spinnaker_testbase/root_test_case.py
+++ b/spinnaker_testbase/root_test_case.py
@@ -97,7 +97,6 @@ class RootTestCase(unittest.TestCase):
                 method()
                 break
             except (JobDestroyedError, SpinnmanException) as ex:
-                print("here")
                 class_file = sys.modules[self.__module__].__file__
                 with open(self.error_file(), "a") as error_file:
                     error_file.write(class_file)

--- a/spinnaker_testbase/script_checker.py
+++ b/spinnaker_testbase/script_checker.py
@@ -39,7 +39,19 @@ class ScriptChecker(RootTestCase):
         root_dir = os.path.dirname(integration_tests_directory)
         return os.path.join(root_dir, script)
 
-    def check_script(self, script, broken_msg=None):
+    def check_script(self, script, broken_msg=None, skip_exceptions=None):
+        """
+
+        :param str script: relative path to the file to run
+        :param str broken_msg: message to print instead of raisng an exception
+            no current usecase known
+        :param skip_exceptions: list to expection classes to convert in SkipTest
+        :type skip_exceptions: list(class)
+
+        """
+        if skip_exceptions is None:
+            skip_exceptions = []
+
         global script_checker_shown
 
         script_path = self.script_path(script)
@@ -60,6 +72,9 @@ class ScriptChecker(RootTestCase):
                 if not script_checker_shown:
                     raise SkipTest("{} did not plot".format(script))
         except Exception as ex:  # pylint: disable=broad-except
+            for skip_exception in skip_exceptions:
+                if isinstance(ex, skip_exception):
+                    raise SkipTest(f"{ex} Still not fixed!") from ex
             if broken_msg:
                 self.report(script, broken_msg)
             else:

--- a/spinnaker_testbase/script_checker.py
+++ b/spinnaker_testbase/script_checker.py
@@ -45,7 +45,8 @@ class ScriptChecker(RootTestCase):
         :param str script: relative path to the file to run
         :param str broken_msg: message to print instead of raisng an exception
             no current usecase known
-        :param skip_exceptions: list to expection classes to convert in SkipTest
+        :param skip_exceptions:
+            list to expection classes to convert in SkipTest
         :type skip_exceptions: list(class)
 
         """

--- a/spinnaker_testbase/test_scripts_header
+++ b/spinnaker_testbase/test_scripts_header
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from spinnaker_testbase import ScriptChecker
-from unittest import SkipTest  # pylint: disable=unused-import
 
 
 class TestScripts(ScriptChecker):


### PR DESCRIPTION
Add the ability to convert some exceptions into skip test

Other known skips changed to comments rather than skip tests

needed for:

tested by:
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/skip_exceptions/1/pipeline/