### PR TITLE
dont die if timestamp dir does not exist

### DIFF
--- a/spinnaker_testbase/root_test_case.py
+++ b/spinnaker_testbase/root_test_case.py
@@ -17,6 +17,7 @@ import sys
 import time
 import unittest
 from unittest import SkipTest
+from spinn_utilities.exceptions import NotSetupException
 from spinnman.exceptions import SpinnmanException
 from spinn_utilities.config_holder import (
     get_config_bool, get_config_str, has_config_option)
@@ -70,7 +71,11 @@ class RootTestCase(unittest.TestCase):
             message += "\n"
         global_reports = os.environ.get("GLOBAL_REPORTS", None)
         if not global_reports:
-            global_reports = FecDataView.get_timestamp_dir_path()
+            try:
+                global_reports = FecDataView.get_timestamp_dir_path()
+            except NotSetupException:
+                # This may happen if you are running none script fiels locally
+                return
 
         if not os.path.exists(global_reports):
             # It might now exist if run in parallel


### PR DESCRIPTION
This fixes the case where a py file is tested as if it is a script but in fact is not
For example
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/blob/7865c26bba59fbc5ec146ec8003fc7f9e309a9d1/gfe_integration_tests/test_scripts.py#L51

The script tester will then report how long it took (as it does with all others)

But local setups may not have a GLOBAL_REPORTS environment variable
The default to write to the parent reports folder fails too as it was never created

So just dont report.

Can only be tested locally as Jenkins has GLOBAL_REPORTS environment variable
